### PR TITLE
Modify OnItemRemove(d)FromInventory to use itemid instead of slotid

### DIFF
--- a/inventory.inc
+++ b/inventory.inc
@@ -83,11 +83,11 @@ forward OnItemAddedToInventory(playerid, itemid);
 
 // Before an item is removed from a player's inventory by the function
 // `RemoveItemFromInventory`. Return 1 to cancel.
-forward OnItemRemoveFromInventory(playerid, slot);
+forward OnItemRemoveFromInventory(playerid, Item:itemid);
 
 // Called after an item is removed from a player's inventory by the function
 // `RemoveItemFromInventory`.
-forward OnItemRemovedFromInventory(playerid, slot);
+forward OnItemRemovedFromInventory(playerid, Item:itemid);
 
 
 static
@@ -123,8 +123,11 @@ stock RemoveItemFromInventory(playerid, slotid, call = 1) {
 		return 1;
 	}
 
+	new Item:itemid;
+	GetInventorySlotItem(playerid, slotid, itemid);
+
 	if(call) {
-		if(CallLocalFunction("OnItemRemoveFromInventory", "dd", playerid, slotid)) {
+		if(CallLocalFunction("OnItemRemoveFromInventory", "dd", playerid, _:itemid)) {
 			return 0;
 		}
 	}
@@ -135,7 +138,7 @@ stock RemoveItemFromInventory(playerid, slotid, call = 1) {
 	}
 
 	if(call) {
-		CallLocalFunction("OnItemRemovedFromInventory", "dd", playerid, slotid);
+		CallLocalFunction("OnItemRemovedFromInventory", "dd", playerid, _:itemid);
 	}
 
 	return 1;

--- a/inventory.inc
+++ b/inventory.inc
@@ -83,11 +83,11 @@ forward OnItemAddedToInventory(playerid, itemid);
 
 // Before an item is removed from a player's inventory by the function
 // `RemoveItemFromInventory`. Return 1 to cancel.
-forward OnItemRemoveFromInventory(playerid, Item:itemid);
+forward OnItemRemoveFromInventory(playerid, slot, Item:itemid);
 
 // Called after an item is removed from a player's inventory by the function
 // `RemoveItemFromInventory`.
-forward OnItemRemovedFromInventory(playerid, Item:itemid);
+forward OnItemRemovedFromInventory(playerid, slot, Item:itemid);
 
 
 static
@@ -127,7 +127,7 @@ stock RemoveItemFromInventory(playerid, slotid, call = 1) {
 	GetInventorySlotItem(playerid, slotid, itemid);
 
 	if(call) {
-		if(CallLocalFunction("OnItemRemoveFromInventory", "dd", playerid, _:itemid)) {
+		if(CallLocalFunction("OnItemRemoveFromInventory", "ddd", playerid, slotid, _:itemid)) {
 			return 0;
 		}
 	}
@@ -138,7 +138,7 @@ stock RemoveItemFromInventory(playerid, slotid, call = 1) {
 	}
 
 	if(call) {
-		CallLocalFunction("OnItemRemovedFromInventory", "dd", playerid, _:itemid);
+		CallLocalFunction("OnItemRemovedFromInventory", "ddd", playerid, slotid, _:itemid);
 	}
 
 	return 1;


### PR DESCRIPTION
It's a breaking change for people using these events. 
For some reason two events - `OnItemRemoveFromInventory` and `OnItemRemovedFromInventory` use slotid instead of itemid to indicate what item is being removed. This means to find out what item it is, we have so use `GetInventorySlotItem`, except this won't work for the latter event, since the item had already been removed thus the old slotid points to a different item (if any at all).

In theory we could leave the slotid in the first event I mentioned but this doesn't seem consistent to me.

I believe it's been unnoticed because ScavengeSurvive gamemode uses only containerid in those events.

If there's everything OK with these changes, I will make a PR to the container repository as well.