### PR TITLE
Check if container is valid in GetItemInventoryPlayer

### DIFF
--- a/inventory.inc
+++ b/inventory.inc
@@ -203,6 +203,10 @@ stock GetItemInventoryPlayer(Item:itemid, &playerid) {
 		return ret;
 	}
 
+	if(!IsValidContainer(containerid)) {
+		return 2;
+	}
+
 	playerid = inv_ContainerPlayer[containerid];
 	return 0;
 }


### PR DESCRIPTION
If the container isn't valid (e.g. the item isn't in any container), we'll get INVALID_CONTAINER_ID. Trying to use that value as an array index will result in the array out of bounds error.